### PR TITLE
Fix build arg

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -72,7 +72,7 @@ if [ -n "${PLUGIN_CACHE_TTL:-}" ]; then
 fi
 
 if [ -n "${PLUGIN_BUILD_ARGS:-}" ]; then
-    BUILD_ARGS=$(echo "${PLUGIN_BUILD_ARGS}" | tr ',' '\n' | while read -r build_arg; do echo "--build-arg \"${build_arg}\""; done)
+    BUILD_ARGS=$(echo "${PLUGIN_BUILD_ARGS}" | tr ',' '\n' | while read -r build_arg; do echo "--build-arg ${build_arg}"; done)
 fi
 
 BUILD_ARGS_FROM_ENV=""


### PR DESCRIPTION
Currently build arg parameter is still not working. I tested it with the following setup.

Dockerfile:
```
FROM debian:12-slim
ARG TARGETARCH
RUN env
```

env:
```
PLUGIN_BUILD_ARGS=TARGETARCH=amd64
```

![image](https://github.com/user-attachments/assets/07d21d65-2367-4d2b-b70c-3614ea4db029)

After removing the quotes, it works well.

![image](https://github.com/user-attachments/assets/4e08b85e-2647-4996-9f76-6cfc6522ac79)
