### PR TITLE
Use current format of ENV in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM gcr.io/kaniko-project/executor:v1.22.0-debug
 
-ENV HOME /root
-ENV USER root
+ENV HOME=/root
+ENV USER=root
 ENV SSL_CERT_DIR=/kaniko/ssl/certs
-ENV DOCKER_CONFIG /kaniko/.docker/
-ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
+ENV DOCKER_CONFIG=/kaniko/.docker/
+ENV DOCKER_CREDENTIAL_GCR_CONFIG=/kaniko/.config/gcloud/docker_credential_gcr_config.json
 
 # add the wrapper which acts as a drone plugin
 COPY plugin.sh /kaniko/plugin.sh


### PR DESCRIPTION
Fix warnings of https://ci.woodpecker-ci.org/repos/8981/pipeline/182/3